### PR TITLE
Add support for Pymatgen StructureGraph with different local_env strategies

### DIFF
--- a/cgcnn/data.py
+++ b/cgcnn/data.py
@@ -282,8 +282,8 @@ class CIFData(Dataset):
         The cutoff radius for searching neighbors
     nn_object: pymatgen.analysis.local_env.NearNeighbors object 
         Instance of a Pymatgen NN object to construct a StructureGraph.
-        Ensures only sites in radius are included. Set radius=None for
-        standard usage of the Pymatgen local_env_strategy
+        Ensures only sites in radius are included. Set radius=None and
+        max_num_nbr=None for standard usage of the Pymatgen local_env_strategy
     dmin: float
         The minimum distance for constructing GaussianDistance
     step: float
@@ -336,8 +336,12 @@ class CIFData(Dataset):
             for i in range(len(crystal)):
                 nbr = graph.get_connected_sites(i)
                 nbr = sorted([nbrs for nbrs in nbr if nbrs.dist <= self.radius],key=lambda x: x.dist)
-                nbr_fea_idx.append([x.index for x in nbr][:self.max_num_nbr])
-                nbr_fea.append([x.dist for x in nbr][:self.max_num_nbr])
+                if self.max_num_nbr is None:
+	                nbr_fea_idx.append([x.index for x in nbr])
+	                nbr_fea.append([x.dist for x in nbr])
+                else:
+	                nbr_fea_idx.append([x.index for x in nbr][:self.max_num_nbr])
+	                nbr_fea.append([x.dist for x in nbr][:self.max_num_nbr])
         else:
             all_nbrs = crystal.get_all_neighbors(self.radius, include_index=True)
             all_nbrs = [sorted(nbrs, key=lambda x: x[1]) for nbrs in all_nbrs]

--- a/cgcnn/data.py
+++ b/cgcnn/data.py
@@ -309,7 +309,7 @@ class CIFData(Dataset):
         assert os.path.exists(id_prop_file), 'id_prop.csv does not exist!'
         with open(id_prop_file) as f:
             reader = csv.reader(f)
-            self.id_prop_data = [row for row in reader]
+            self.id_prop_data = [[x.strip().replace('\ufeff','') for x in row] for row in reader]
         random.seed(random_seed)
         random.shuffle(self.id_prop_data)
         atom_init_file = os.path.join(self.root_dir, 'atom_init.json')

--- a/cgcnn/data.py
+++ b/cgcnn/data.py
@@ -331,6 +331,8 @@ class CIFData(Dataset):
         nbr_fea_idx, nbr_fea = [], []
         if self.nn_object:
             graph = StructureGraph.with_local_env_strategy(crystal, self.nn_object)
+            if self.radius is None:
+                self.radius = np.inf
             for i in range(len(crystal)):
                 nbr = graph.get_connected_sites(i)
                 nbr = sorted([nbrs for nbrs in nbr if nbrs.dist <= self.radius],key=lambda x: x.dist)

--- a/cgcnn/data.py
+++ b/cgcnn/data.py
@@ -303,7 +303,7 @@ class CIFData(Dataset):
     def __init__(self, root_dir, max_num_nbr=12, radius=8, nn_object=None,
                  dmin=0, step=0.2,random_seed=123):
         self.root_dir = root_dir
-        self.max_num_nbr, self.radius = max_num_nbr, radius
+        self.max_num_nbr, self.radius, self.nn_object = max_num_nbr, radius, nn_object
         assert os.path.exists(root_dir), 'root_dir does not exist!'
         id_prop_file = os.path.join(self.root_dir, 'id_prop.csv')
         assert os.path.exists(id_prop_file), 'id_prop.csv does not exist!'

--- a/cgcnn/data.py
+++ b/cgcnn/data.py
@@ -281,9 +281,9 @@ class CIFData(Dataset):
     radius: float
         The cutoff radius for searching neighbors
     nn_object: pymatgen.analysis.local_env.NearNeighbors object 
-        A Pymatgen NN object to construct a StructureGraph
+        Instance of a Pymatgen NN object to construct a StructureGraph.
         Ensures only sites in radius are included. Set radius=None for
-        no standard usage of the Pymatgen local_env_strategy
+        standard usage of the Pymatgen local_env_strategy
     dmin: float
         The minimum distance for constructing GaussianDistance
     step: float


### PR DESCRIPTION
Currently, the approach to generating the crystal graph is based on cutoff radii, which are not necessarily ideal for most materials. It would be much better if `cgcnn` were able to use Pymatgen's `pymatgen.analysis.graphs.StructureGraph` function to generate a crystal graph via one of its several `pymatgen.analysis.local_env` strategies.

This PR provides support for a new argument in `CIFData` within `data.py` to allow for the use of Pymatgen's `StructureGraph` function. One can now provide the `nn_object` argument to the `CIFData` function, which must be an instance of a `pymatgen.analysis.local_env.NearNeighbors` object. An example of a `NearNeighbors` object would be `nn_object = CrystalNN()` following an import of `from pymatgen.analysis.local_env import CrystalNN`. The new `nn_object` argument accounts for the user-specified `max_num_nbr` and `radius`, although the `radius` should usually be set to `radius=None` if one is using Pymatgen's built-in `local_env` strategies.